### PR TITLE
testing integration test

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -349,6 +349,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			HashMapDictionaryBuilder.<String, Object>put(
 				"companyId", companyIds
 			).put(
+				"liferay.filter.disabled", true
+			).put(
 				"liferay.jackson", false
 			).put(
 				"liferay.objects", true

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -472,44 +472,6 @@ public class PredicateExpressionVisitorImpl
 		return entityModel;
 	}
 
-	private Predicate _getPredicate(
-		Object left, long objectDefinitionId,
-		BinaryExpression.Operation operation, Object right) {
-
-		Predicate predicate = null;
-
-		if (Objects.equals(BinaryExpression.Operation.AND, operation)) {
-			predicate = Predicate.and(
-				Predicate.withParentheses((Predicate)left),
-				Predicate.withParentheses((Predicate)right));
-		}
-		else if (Objects.equals(BinaryExpression.Operation.OR, operation)) {
-			predicate = Predicate.or(
-				Predicate.withParentheses((Predicate)left),
-				Predicate.withParentheses((Predicate)right));
-		}
-		else {
-			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-				objectDefinitionId, String.valueOf(left));
-
-			if ((objectField != null) &&
-				StringUtil.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
-
-				predicate = _contains(left, right, objectDefinitionId);
-			}
-		}
-
-		if (predicate != null) {
-			return predicate;
-		}
-
-		return _getExpressionPredicate(
-			_getColumn(left, objectDefinitionId), operation,
-			_getValue(left, objectDefinitionId, right));
-	}
-
 	private Predicate _getObjectRelationshipPredicate(
 		Object left,
 		UnsafeBiFunction<String, Long, Predicate, Exception> unsafeBiFunction) {
@@ -559,6 +521,44 @@ public class PredicateExpressionVisitorImpl
 
 		return objectRelatedModelsPredicateProvider.getPredicate(
 			objectRelationship, predicate);
+	}
+
+	private Predicate _getPredicate(
+		Object left, long objectDefinitionId,
+		BinaryExpression.Operation operation, Object right) {
+
+		Predicate predicate = null;
+
+		if (Objects.equals(BinaryExpression.Operation.AND, operation)) {
+			predicate = Predicate.and(
+				Predicate.withParentheses((Predicate)left),
+				Predicate.withParentheses((Predicate)right));
+		}
+		else if (Objects.equals(BinaryExpression.Operation.OR, operation)) {
+			predicate = Predicate.or(
+				Predicate.withParentheses((Predicate)left),
+				Predicate.withParentheses((Predicate)right));
+		}
+		else {
+			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+				objectDefinitionId, String.valueOf(left));
+
+			if ((objectField != null) &&
+				StringUtil.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
+
+				predicate = _contains(left, right, objectDefinitionId);
+			}
+		}
+
+		if (predicate != null) {
+			return predicate;
+		}
+
+		return _getExpressionPredicate(
+			_getColumn(left, objectDefinitionId), operation,
+			_getValue(left, objectDefinitionId, right));
 	}
 
 	private long _getRelatedObjectDefinitionId(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -99,7 +99,7 @@ public class PredicateExpressionVisitorImpl
 		Predicate predicate = null;
 
 		if (_isComplexProperExpression(left)) {
-			predicate = _getPredicateForRelationships(
+			predicate = _getObjectRelationshipPredicate(
 				left,
 				(objectFieldName, relatedObjectDefinitionId) -> _getPredicate(
 					objectFieldName, relatedObjectDefinitionId, operation,
@@ -137,7 +137,7 @@ public class PredicateExpressionVisitorImpl
 			complexPropertyExpression.getPropertyExpression();
 
 		if (propertyExpression instanceof CollectionPropertyExpression) {
-			return _getPredicateForRelationships(
+			return _getObjectRelationshipPredicate(
 				complexPropertyExpression.toString(),
 				(objectFieldName, relatedObjectDefinitionId) ->
 					_visitCollectionPropertyExpression(
@@ -175,7 +175,7 @@ public class PredicateExpressionVisitorImpl
 			Predicate predicate = null;
 
 			if (_isComplexProperExpression(left)) {
-				predicate = _getPredicateForRelationships(
+				predicate = _getObjectRelationshipPredicate(
 					left,
 					(objectFieldName, relatedObjectDefinitionId) ->
 						_getInPredicate(
@@ -258,7 +258,7 @@ public class PredicateExpressionVisitorImpl
 
 			if (type == MethodExpression.Type.CONTAINS) {
 				if (_isComplexProperExpression(left)) {
-					predicate = _getPredicateForRelationships(
+					predicate = _getObjectRelationshipPredicate(
 						left,
 						(objectFieldName, relatedObjectDefinitionId) ->
 							_contains(
@@ -276,7 +276,7 @@ public class PredicateExpressionVisitorImpl
 			}
 			else if (type == MethodExpression.Type.STARTS_WITH) {
 				if (_isComplexProperExpression(left)) {
-					predicate = _getPredicateForRelationships(
+					predicate = _getObjectRelationshipPredicate(
 						left,
 						(objectFieldName, relatedObjectDefinitionId) ->
 							_startsWith(
@@ -510,7 +510,7 @@ public class PredicateExpressionVisitorImpl
 			_getValue(left, objectDefinitionId, right));
 	}
 
-	private Predicate _getPredicateForRelationships(
+	private Predicate _getObjectRelationshipPredicate(
 		Object left,
 		UnsafeBiFunction<String, Long, Predicate, Exception> unsafeBiFunction) {
 
@@ -527,7 +527,7 @@ public class PredicateExpressionVisitorImpl
 			String objectFieldName = leftStringParts[1];
 
 			try {
-				return _getPredicateForRelationships(
+				return _getObjectRelationshipPredicate(
 					objectRelationship,
 					unsafeBiFunction.apply(
 						objectFieldName,
@@ -542,7 +542,7 @@ public class PredicateExpressionVisitorImpl
 		return null;
 	}
 
-	private Predicate _getPredicateForRelationships(
+	private Predicate _getObjectRelationshipPredicate(
 			ObjectRelationship objectRelationship, Predicate predicate)
 		throws Exception {
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
@@ -21,14 +21,16 @@ import com.liferay.object.rest.internal.odata.filter.expression.PredicateExpress
 import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.Filter;
 import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.portal.odata.filter.expression.Expression;
+import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
+
+import javax.ws.rs.ServerErrorException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -62,11 +64,17 @@ public class FilterPredicateFactoryImpl implements FilterPredicateFactory {
 					_objectFieldBusinessTypeRegistry, _objectFieldLocalService,
 					_objectRelatedModelsPredicateProviderRegistry));
 		}
-		catch (Exception exception) {
-			_log.error(exception);
+		catch (ExpressionVisitException expressionVisitException) {
+			throw new InvalidFilterException(
+				expressionVisitException.getMessage(),
+				expressionVisitException);
 		}
-
-		return null;
+		catch (InvalidFilterException invalidFilterException) {
+			throw invalidFilterException;
+		}
+		catch (Exception exception) {
+			throw new ServerErrorException(500, exception);
+		}
 	}
 
 	@Override
@@ -76,9 +84,6 @@ public class FilterPredicateFactoryImpl implements FilterPredicateFactory {
 
 		return create(entityModel, filterString, objectDefinitionId);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		FilterPredicateFactoryImpl.class);
 
 	@Reference
 	private FilterParserProvider _filterParserProvider;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -43,7 +43,6 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.AcceptLanguageC
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.AggregationContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.CompanyContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FieldsQueryParamContextProvider;
-import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FilterContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.PaginationContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.RestrictFieldsQueryParamContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.SortContextProvider;
@@ -157,9 +156,6 @@ public class VulcanFeature implements Feature {
 		featureContext.register(
 			new EntityExtensionHandlerContextResolver(
 				_extensionProviderRegistry));
-		featureContext.register(
-			new FilterContextProvider(
-				_expressionConvert, _filterParserProvider, _language, _portal));
 		featureContext.register(
 			new MultipartBodyMessageBodyReader(
 				_dlValidator.getMaxAllowableSize(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFilterFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFilterFeature.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.feature;
+
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FilterContextProvider;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@Component(
+	property = {
+		JaxrsWhiteboardConstants.JAX_RS_APPLICATION_SELECT + "=(|(!(liferay.filter.disabled=*))(liferay.filter.disabled=false))",
+		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+		JaxrsWhiteboardConstants.JAX_RS_NAME + "=Liferay.Vulcan.Filter"
+	},
+	scope = ServiceScope.PROTOTYPE, service = Feature.class
+)
+public class VulcanFilterFeature implements Feature {
+
+	@Override
+	public boolean configure(FeatureContext featureContext) {
+		featureContext.register(
+			new FilterContextProvider(
+				_expressionConvert, _filterParserProvider, _language, _portal));
+
+		return false;
+	}
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
@@ -118,7 +118,7 @@ public class FilterContextProviderTest {
 	private ContextProvider<Filter> _contextProvider;
 
 	@Inject(
-		filter = "component.name=com.liferay.portal.vulcan.internal.jaxrs.feature.VulcanFeature"
+		filter = "component.name=com.liferay.portal.vulcan.internal.jaxrs.feature.VulcanFilterFeature"
 	)
 	private Feature _feature;
 

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -80,6 +80,43 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	}
 
 	@Test
+	public void testRegisterInitialDeploymentAndRunOnPortalUpgradeVerifyProcessAfterInitialDeploymentUpgradeProcess() {
+		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(true, true)) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testRegisterInitialDeploymentAndRunOnPortalUpgradeVerifyProcessAfterModuleUpgrade() {
+		_simulateUpgradeProcessExecution();
+
+		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				true, true)) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testRegisterInitialDeploymentAndRunOnPortalUpgradeVerifyProcessDuringInitialDeployment() {
+		try (SafeCloseable safeCloseable = _registerVerifyProcess(true, true)) {
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testRegisterInitialDeploymentAndRunOnPortalUpgradeVerifyProcessDuringPortalUpgrade() {
+		try (SafeCloseable safeCloseable1 = _upgradePortal();
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				true, false)) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
 	public void testRegisterInitialDeploymentVerifyProcessAfterInitialDeploymentUpgradeProcess() {
 		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -76,7 +76,18 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			_releaseLocalService.deleteRelease(release);
 		}
 
+		_forceFailure = false;
+
 		_verifyProcessRun = false;
+	}
+
+	@Test
+	public void testRegisterFailedVerifyProcess() {
+		_forceFailure = true;
+
+		try (SafeCloseable safeCloseable = _registerVerifyProcess(true, true)) {
+			_checkResult(true);
+		}
 	}
 
 	@Test
@@ -245,7 +256,12 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			return;
 		}
 
-		Assert.assertTrue(release.getVerified());
+		if (_forceFailure) {
+			Assert.assertFalse(release.getVerified());
+		}
+		else {
+			Assert.assertTrue(release.getVerified());
+		}
 	}
 
 	private SafeCloseable _executeInitialUpgradeProcess() {
@@ -311,6 +327,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Inject
 	private CounterLocalService _counterLocalService;
 
+	private boolean _forceFailure;
+
 	@Inject
 	private ReleaseLocalService _releaseLocalService;
 
@@ -325,6 +343,10 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		@Override
 		protected void doVerify() throws Exception {
 			_verifyProcessRun = true;
+
+			if (_forceFailure) {
+				throw new Exception();
+			}
 		}
 
 	}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -77,7 +77,6 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		}
 
 		_forceFailure = false;
-
 		_verifyProcessRun = false;
 	}
 
@@ -86,7 +85,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		_forceFailure = true;
 
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(true, true)) {
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -95,7 +94,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(true, true)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -106,14 +105,14 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, true)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
 	@Test
 	public void testRegisterInitialDeploymentAndRunOnPortalUpgradeVerifyProcessDuringInitialDeployment() {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(true, true)) {
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -122,7 +121,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable1 = _upgradePortal();
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(true, true)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -132,7 +131,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, false)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -143,7 +142,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, false)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -152,7 +151,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(
 				true, false)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -162,7 +161,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, false)) {
 
-			_checkResult(false);
+			_assertVerify(false);
 		}
 	}
 
@@ -172,7 +171,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, true)) {
 
-			_checkResult(false);
+			_assertVerify(false);
 		}
 	}
 
@@ -183,7 +182,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, true)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -192,7 +191,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(
 				false, true)) {
 
-			_checkResult(false);
+			_assertVerify(false);
 		}
 	}
 
@@ -202,7 +201,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, true)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -212,7 +211,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, false)) {
 
-			_checkResult(false);
+			_assertVerify(false);
 		}
 	}
 
@@ -223,7 +222,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, false)) {
 
-			_checkResult(true);
+			_assertVerify(true);
 		}
 	}
 
@@ -232,7 +231,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(
 				false, false)) {
 
-			_checkResult(false);
+			_assertVerify(false);
 		}
 	}
 
@@ -242,11 +241,11 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, false)) {
 
-			_checkResult(false);
+			_assertVerify(false);
 		}
 	}
 
-	private void _checkResult(boolean verifyProcessRun) {
+	private void _assertVerify(boolean verifyProcessRun) {
 		Assert.assertEquals(verifyProcessRun, _verifyProcessRun);
 
 		if (!verifyProcessRun) {

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -120,8 +120,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Test
 	public void testRegisterInitialDeploymentAndRunOnPortalUpgradeVerifyProcessDuringPortalUpgrade() {
 		try (SafeCloseable safeCloseable1 = _upgradePortal();
-			SafeCloseable safeCloseable2 = _registerVerifyProcess(
-				true, false)) {
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(true, true)) {
 
 			_checkResult(true);
 		}
@@ -248,13 +247,15 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	}
 
 	private void _checkResult(boolean verifyProcessRun) {
-		Release release = _releaseLocalService.fetchRelease(_symbolicName);
+		Assert.assertEquals(verifyProcessRun, _verifyProcessRun);
 
 		if (!verifyProcessRun) {
-			Assert.assertNull(release);
-
 			return;
 		}
+
+		Release release = _releaseLocalService.fetchRelease(_symbolicName);
+
+		Assert.assertNotNull(release);
 
 		if (_forceFailure) {
 			Assert.assertFalse(release.getVerified());

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -82,7 +82,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Test
 	public void testRegisterInitialDeploymentVerifyProcessAfterInitialDeploymentUpgradeProcess() {
 		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
-			SafeCloseable safeCloseable2 = _registerInitialVerifyProcess()) {
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				true, false)) {
 
 			Assert.assertTrue(_verifyProcessRun);
 		}
@@ -92,14 +93,18 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	public void testRegisterInitialDeploymentVerifyProcessAfterModuleUpgrade() {
 		_simulateUpgradeProcessExecution();
 
-		try (SafeCloseable safeCloseable2 = _registerInitialVerifyProcess()) {
+		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				true, false)) {
+
 			Assert.assertTrue(_verifyProcessRun);
 		}
 	}
 
 	@Test
 	public void testRegisterInitialDeploymentVerifyProcessDuringInitialDeployment() {
-		try (SafeCloseable safeCloseable = _registerInitialVerifyProcess()) {
+		try (SafeCloseable safeCloseable = _registerVerifyProcess(
+				true, false)) {
+
 			Assert.assertTrue(_verifyProcessRun);
 		}
 	}
@@ -107,7 +112,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Test
 	public void testRegisterInitialDeploymentVerifyProcessDuringPortalUpgrade() {
 		try (SafeCloseable safeCloseable1 = _upgradePortal();
-			SafeCloseable safeCloseable2 = _registerInitialVerifyProcess()) {
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				true, false)) {
 
 			Assert.assertFalse(_verifyProcessRun);
 		}
@@ -116,8 +122,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Test
 	public void testRegisterRunOnPortalUpgradeVerifyProcessAfterInitialDeploymentUpgradeProcess() {
 		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
-			SafeCloseable safeCloseable2 =
-				_registerRunOnPortalUpgradeVerifyProcess()) {
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				false, true)) {
 
 			Assert.assertFalse(_verifyProcessRun);
 		}
@@ -127,8 +133,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	public void testRegisterRunOnPortalUpgradeVerifyProcessAfterModuleUpgrade() {
 		_simulateUpgradeProcessExecution();
 
-		try (SafeCloseable safeCloseable2 =
-				_registerRunOnPortalUpgradeVerifyProcess()) {
+		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				false, true)) {
 
 			Assert.assertTrue(_verifyProcessRun);
 		}
@@ -136,8 +142,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 
 	@Test
 	public void testRegisterRunOnPortalUpgradeVerifyProcessDuringInitialDeployment() {
-		try (SafeCloseable safeCloseable =
-				_registerRunOnPortalUpgradeVerifyProcess()) {
+		try (SafeCloseable safeCloseable = _registerVerifyProcess(
+				false, true)) {
 
 			Assert.assertFalse(_verifyProcessRun);
 		}
@@ -146,8 +152,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Test
 	public void testRegisterRunOnPortalUpgradeVerifyProcessDuringPortalUpgrade() {
 		try (SafeCloseable safeCloseable1 = _upgradePortal();
-			SafeCloseable safeCloseable2 =
-				_registerRunOnPortalUpgradeVerifyProcess()) {
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				false, true)) {
 
 			Assert.assertTrue(_verifyProcessRun);
 		}
@@ -156,7 +162,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Test
 	public void testRegisterVerifyProcessAfterInitialDeploymentUpgradeProcess() {
 		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
-			SafeCloseable safeCloseable2 = _registerVerifyProcess()) {
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				false, false)) {
 
 			Assert.assertFalse(_verifyProcessRun);
 		}
@@ -166,14 +173,18 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	public void testRegisterVerifyProcessAfterModuleUpgrade() {
 		_simulateUpgradeProcessExecution();
 
-		try (SafeCloseable safeCloseable2 = _registerVerifyProcess()) {
+		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				false, false)) {
+
 			Assert.assertTrue(_verifyProcessRun);
 		}
 	}
 
 	@Test
 	public void testRegisterVerifyProcessDuringInitialDeployment() {
-		try (SafeCloseable safeCloseable = _registerVerifyProcess()) {
+		try (SafeCloseable safeCloseable = _registerVerifyProcess(
+				false, false)) {
+
 			Assert.assertFalse(_verifyProcessRun);
 		}
 	}
@@ -181,7 +192,8 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Test
 	public void testRegisterVerifyProcessDuringUpgradePortal() {
 		try (SafeCloseable safeCloseable1 = _upgradePortal();
-			SafeCloseable safeCloseable2 = _registerVerifyProcess()) {
+			SafeCloseable safeCloseable2 = _registerVerifyProcess(
+				false, false)) {
 
 			Assert.assertFalse(_verifyProcessRun);
 		}
@@ -202,34 +214,17 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		return upgradeStepServiceRegistration::unregister;
 	}
 
-	private SafeCloseable _registerInitialVerifyProcess() {
-		ServiceRegistration<VerifyProcess>
-			initialDeploymentVerifyProcessRegistration =
-				_bundleContext.registerService(
-					VerifyProcess.class, _initialDeploymentVerifyProcess,
-					HashMapDictionaryBuilder.<String, Object>put(
-						"initial.deployment", true
-					).build());
+	private SafeCloseable _registerVerifyProcess(
+		boolean initialDeployment, boolean runOnPortalUpgrade) {
 
-		return initialDeploymentVerifyProcessRegistration::unregister;
-	}
-
-	private SafeCloseable _registerRunOnPortalUpgradeVerifyProcess() {
-		ServiceRegistration<VerifyProcess>
-			runOnPortalUpgradeVerifyProcessRegistration =
-				_bundleContext.registerService(
-					VerifyProcess.class, _runOnPortalUpgradeVerifyProcess,
-					HashMapDictionaryBuilder.<String, Object>put(
-						"run.on.portal.upgrade", true
-					).build());
-
-		return runOnPortalUpgradeVerifyProcessRegistration::unregister;
-	}
-
-	private SafeCloseable _registerVerifyProcess() {
 		ServiceRegistration<VerifyProcess> verifyProcessRegistration =
 			_bundleContext.registerService(
-				VerifyProcess.class, _verifyProcess, null);
+				VerifyProcess.class, _verifyProcess,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"initial.deployment", initialDeployment
+				).put(
+					"run.on.portal.upgrade", runOnPortalUpgrade
+				).build());
 
 		return verifyProcessRegistration::unregister;
 	}
@@ -267,14 +262,9 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Inject
 	private CounterLocalService _counterLocalService;
 
-	private final VerifyProcessTest _initialDeploymentVerifyProcess =
-		new VerifyProcessTest();
-
 	@Inject
 	private ReleaseLocalService _releaseLocalService;
 
-	private final VerifyProcessTest _runOnPortalUpgradeVerifyProcess =
-		new VerifyProcessTest();
 	private final VerifyProcessTest _verifyProcess = new VerifyProcessTest();
 	private boolean _verifyProcessRun;
 

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -84,7 +84,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(true, true)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -95,14 +95,14 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, true)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
 	@Test
 	public void testRegisterInitialDeploymentAndRunOnPortalUpgradeVerifyProcessDuringInitialDeployment() {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(true, true)) {
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -112,7 +112,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, false)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -122,7 +122,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, false)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -133,7 +133,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, false)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -142,7 +142,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(
 				true, false)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -152,7 +152,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				true, false)) {
 
-			Assert.assertFalse(_verifyProcessRun);
+			_checkResult(false);
 		}
 	}
 
@@ -162,7 +162,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, true)) {
 
-			Assert.assertFalse(_verifyProcessRun);
+			_checkResult(false);
 		}
 	}
 
@@ -173,7 +173,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, true)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -182,7 +182,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(
 				false, true)) {
 
-			Assert.assertFalse(_verifyProcessRun);
+			_checkResult(false);
 		}
 	}
 
@@ -192,7 +192,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, true)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -202,7 +202,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, false)) {
 
-			Assert.assertFalse(_verifyProcessRun);
+			_checkResult(false);
 		}
 	}
 
@@ -213,7 +213,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, false)) {
 
-			Assert.assertTrue(_verifyProcessRun);
+			_checkResult(true);
 		}
 	}
 
@@ -222,7 +222,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		try (SafeCloseable safeCloseable = _registerVerifyProcess(
 				false, false)) {
 
-			Assert.assertFalse(_verifyProcessRun);
+			_checkResult(false);
 		}
 	}
 
@@ -232,8 +232,20 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
 				false, false)) {
 
-			Assert.assertFalse(_verifyProcessRun);
+			_checkResult(false);
 		}
+	}
+
+	private void _checkResult(boolean verifyProcessRun) {
+		Release release = _releaseLocalService.fetchRelease(_symbolicName);
+
+		if (!verifyProcessRun) {
+			Assert.assertNull(release);
+
+			return;
+		}
+
+		Assert.assertTrue(release.getVerified());
 	}
 
 	private SafeCloseable _executeInitialUpgradeProcess() {

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -258,10 +258,10 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		Assert.assertNotNull(release);
 
 		if (_forceFailure) {
-			Assert.assertFalse(release.getVerified());
+			Assert.assertFalse(release.isVerified());
 		}
 		else {
-			Assert.assertTrue(release.getVerified());
+			Assert.assertTrue(release.isVerified());
 		}
 	}
 


### PR DESCRIPTION
- LPS-173250 Avoid return null. Instead of it, handle the exception properly. In this case, it is better to throw the exception so the ExceptionMapper associated will return the proper code and message to the client. In case that an unexpected exception occurs, we throw an 500 error.
- LPS-173250 Add a feature for the filtering. This filtering will be added to all Liferay REST APIs that uses elastic search to filtering. In Objects, as we do not use elastic search anymore, it is not necessary to provide the whole mechanism to create a Filter for elastic. So this PR disable that conversion. It still works because the conversion from filter string to a Predicate is made in Objects. So this is also a performance improve because instead of convert the string to a Filter (which is useless for Objects) and a Predicate, we convert it directly to a Predicate
- LPS-173250 Check the case where a complex property contains a collection property and handle it properly.
- LPS-173250 Update feature in FilterContextProviderTest to use the new feature dedicated to the filtering.
- LPS-173250 Rename
- LPS-173250 Auto SF
- LPS-165832 Modify the methods to allow all possible configuration options
- LPS-165832 Test all cases when a verify process is initial deployment and run on portal upgrade
- LPS-173444 Add a more complete check to validate we use the bundleSymbolicName and the verified column is correct
- LPS-173444 Validate failure case
- LPS-173444 Fix errors after testing
- LPS-173444 SF
- LPS-165832 Rename
- LPS-175921 CI test
